### PR TITLE
Fix underflow and fix wireguard platform init

### DIFF
--- a/components/tailscale/http2_session.cpp
+++ b/components/tailscale/http2_session.cpp
@@ -875,7 +875,7 @@ bool Http2Session::has_complete_json_(const char* buffer, size_t buffer_size) {
   }
 
   // Final check: all braces closed, ensure we end with }
-  for (size_t i = buffer_size; i > start_offset && i > buffer_size - 100; i--) {
+  for (size_t i = buffer_size; i > start_offset && i > (buffer_size > 100 ? buffer_size - 100 : 0); i--) {
     char c = buffer[i - 1];
     if (!std::isspace(static_cast<unsigned char>(c))) {
       bool ends_with_brace = (c == '}');

--- a/components/tailscale/wireguard_device_manager.cpp
+++ b/components/tailscale/wireguard_device_manager.cpp
@@ -43,6 +43,7 @@ bool WireGuardDeviceManager::init(const uint8_t* our_private_key) {
   static bool wg_initialized = false;
   if (!wg_initialized) {
     ESP_LOGI(TAG, "Initializing WireGuard library...");
+    wireguard_platform_init();
     wireguard_init();
     wg_initialized = true;
     ESP_LOGI(TAG, "✓ WireGuard library initialized");


### PR DESCRIPTION
Two problems I found when testing the connectivity to the `https://controlplane.tailscale.com`.

The first is a underflow in some JSON validation code, which made it mark `{"KeepAlive":true}` as invalid. Not sure if it was affecting any functionality.

Another is calling `wireguard_platform_init` before using wireguard functions. Otherwise, it was getting stuck in `wireguard_create_handshake_initiation`, in a infinite loop generating random values, which were always equal due to the generator being uninitialized. 